### PR TITLE
Add month abbreviation

### DIFF
--- a/config.json
+++ b/config.json
@@ -13,6 +13,7 @@
   "imageHeight": 1304,
   "rotateAngle": 270,
   "is24h": false,
+  "isMonthAbbr": false,
   "calendars": [
     "primary"
   ]

--- a/maginkcal.py
+++ b/maginkcal.py
@@ -39,6 +39,7 @@ def main():
     rotateAngle = config['rotateAngle']  # If image is rendered in portrait orientation, angle to rotate to fit screen
     calendars = config['calendars']  # Google calendar ids
     is24hour = config['is24h']  # set 24 hour time
+    isMonthAbbr = config['isMonthAbbr'] # Use month abbreviation like 'JAN' instead of month number '1'
 
     # Create and configure logger
     logging.basicConfig(filename="logfile.log", format='%(asctime)s %(levelname)s - %(message)s', filemode='a')
@@ -75,7 +76,7 @@ def main():
         calDict = {'events': eventList, 'calStartDate': calStartDate, 'today': currDate, 'lastRefresh': currDatetime,
                    'batteryLevel': currBatteryLevel, 'batteryDisplayMode': batteryDisplayMode,
                    'dayOfWeekText': dayOfWeekText, 'weekStartDay': weekStartDay, 'maxEventsPerDay': maxEventsPerDay,
-                   'is24hour': is24hour}
+                   'is24hour': is24hour, 'isMonthAbbr': isMonthAbbr}
 
         renderService = RenderHelper(imageWidth, imageHeight, rotateAngle)
         calBlackImage, calRedImage = renderService.process_inputs(calDict)

--- a/render/render.py
+++ b/render/render.py
@@ -116,6 +116,7 @@ class RenderHelper:
         dayOfWeekText = calDict['dayOfWeekText']
         weekStartDay = calDict['weekStartDay']
         is24hour = calDict['is24hour']
+        isMonthAbbr = calDict['isMonthAbbr']
 
         # for each item in the eventList, add them to the relevant day in our calendar list
         for event in calDict['events']:
@@ -132,7 +133,10 @@ class RenderHelper:
             calendar_template = file.read()
 
         # Insert month header
-        month_name = str(calDict['today'].month)
+        if isMonthAbbr:
+            month_name = calendar.month_abbr[calDict['today'].month]
+        else:
+            month_name = str(calDict['today'].month)
 
         # Insert battery icon
         # batteryDisplayMode - 0: do not show / 1: always show / 2: show when battery is low


### PR DESCRIPTION
Add the possibility to use month abbreviation like 'JAN' instead of month number like '1'
Adjustable via `config.json`:
 `"isMonthAbbr": true` --> month abbreviation active
 `"isMonthAbbr": false` --> default value, month abbreviation not active