### PR TITLE
token.pickle -> token.json

### DIFF
--- a/gcal/gcal.py
+++ b/gcal/gcal.py
@@ -10,9 +10,11 @@ import datetime as dt
 import pickle
 import os.path
 import pathlib
-from googleapiclient.discovery import build
-from google_auth_oauthlib.flow import InstalledAppFlow
 from google.auth.transport.requests import Request
+from google.oauth2.credentials import Credentials
+from google_auth_oauthlib.flow import InstalledAppFlow
+from googleapiclient.discovery import build
+from googleapiclient.errors import HttpError
 import logging
 
 
@@ -25,12 +27,11 @@ class GcalHelper:
         self.currPath = str(pathlib.Path(__file__).parent.absolute())
 
         creds = None
-        # The file token.pickle stores the user's access and refresh tokens, and is
+        # The file token.json stores the user's access and refresh tokens, and is
         # created automatically when the authorization flow completes for the first
         # time.
-        if os.path.exists(self.currPath + '/token.pickle'):
-            with open(self.currPath + '/token.pickle', 'rb') as token:
-                creds = pickle.load(token)
+        if os.path.exists(self.currPath + '/token.json'):
+            creds = Credentials.from_authorized_user_file(self.currPath + '/token.json', SCOPES)
         # If there are no (valid) credentials available, let the user log in.
         if not creds or not creds.valid:
             if creds and creds.expired and creds.refresh_token:
@@ -40,8 +41,8 @@ class GcalHelper:
                     self.currPath + '/credentials.json', SCOPES)
                 creds = flow.run_local_server(port=0)
             # Save the credentials for the next run
-            with open(self.currPath + '/token.pickle', 'wb') as token:
-                pickle.dump(creds, token)
+            with open(self.currPath + '/token.json', 'w') as token:
+                token.write(creds.to_json())
 
         self.service = build('calendar', 'v3', credentials=creds, cache_discovery=False)
 

--- a/gcal/quickstart.py
+++ b/gcal/quickstart.py
@@ -1,20 +1,15 @@
-#!/usr/bin/env python3
-# -*- coding: utf-8 -*-
-"""
-Run this script first to obtain the token. Credentials.json must be in the same folder first.
-To obtain Credentials.json, follow the instructions listed in the following link.
-https://developers.google.com/calendar/api/quickstart/python
-"""
-
 from __future__ import print_function
-import datetime
-import pickle
-import os.path
-from googleapiclient.discovery import build
-from google_auth_oauthlib.flow import InstalledAppFlow
-from google.auth.transport.requests import Request
 
-# If modifying these scopes, delete the file token.pickle.
+import datetime
+import os.path
+
+from google.auth.transport.requests import Request
+from google.oauth2.credentials import Credentials
+from google_auth_oauthlib.flow import InstalledAppFlow
+from googleapiclient.discovery import build
+from googleapiclient.errors import HttpError
+
+# If modifying these scopes, delete the file token.json.
 SCOPES = ['https://www.googleapis.com/auth/calendar.readonly']
 
 
@@ -23,12 +18,11 @@ def main():
     Prints the start and name of the next 10 events on the user's calendar.
     """
     creds = None
-    # The file token.pickle stores the user's access and refresh tokens, and is
+    # The file token.json stores the user's access and refresh tokens, and is
     # created automatically when the authorization flow completes for the first
     # time.
-    if os.path.exists('token.pickle'):
-        with open('token.pickle', 'rb') as token:
-            creds = pickle.load(token)
+    if os.path.exists('token.json'):
+        creds = Credentials.from_authorized_user_file('token.json', SCOPES)
     # If there are no (valid) credentials available, let the user log in.
     if not creds or not creds.valid:
         if creds and creds.expired and creds.refresh_token:
@@ -38,26 +32,34 @@ def main():
                 'credentials.json', SCOPES)
             creds = flow.run_local_server(port=0)
         # Save the credentials for the next run
-        with open('token.pickle', 'wb') as token:
-            pickle.dump(creds, token)
+        with open('token.json', 'w') as token:
+            token.write(creds.to_json())
 
-    service = build('calendar', 'v3', credentials=creds)
+    try:
+        service = build('calendar', 'v3', credentials=creds)
 
-    # Call the Calendar API
-    now = datetime.datetime.utcnow().isoformat() + 'Z' # 'Z' indicates UTC time
-    print('Getting the upcoming 10 events')
-    events_result = service.events().list(calendarId='primary', timeMin=now,
-                                        maxResults=10, singleEvents=True,
-                                        orderBy='startTime').execute()
-    events = events_result.get('items', [])
+        # Call the Calendar API
+        now = datetime.datetime.utcnow().isoformat() + 'Z'  # 'Z' indicates UTC time
+        print('Getting the upcoming 10 events')
+        events_result = service.events().list(calendarId='primary', timeMin=now,
+                                              maxResults=10, singleEvents=True,
+                                              orderBy='startTime').execute()
+        events = events_result.get('items', [])
 
-    if not events:
-        print('No upcoming events found.')
-    for event in events:
-        start = event['start'].get('dateTime', event['start'].get('date'))
-        end = event['end'].get('dateTime', event['start'].get('date'))
-        updated = event['updated']
-        print(start + " | " + end + " | " + updated + " | " + event['summary'])
+        if not events:
+            print('No upcoming events found.')
+            return
+
+        # Prints the start and name of the next 10 events
+        for event in events:
+            start = event['start'].get('dateTime', event['start'].get('date'))
+            end = event['end'].get('dateTime', event['start'].get('date'))
+            updated = event['updated']
+            print(start + " | " + end + " | " + updated + " | " + event['summary'])
+
+
+    except HttpError as error:
+        print('An error occurred: %s' % error)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Migration from token.pickle -> token.json

the newest version of the google example on [this site](https://developers.google.com/calendar/api/quickstart/python) uses a different version of the token. In my approach the token.pickle causes some issues after a few days. token.json seems to be more stable